### PR TITLE
Add public docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.1
+
+orbs:
+  docker: circleci/docker@1.4.0
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - docker/publish:
+          context: onesignal-global
+          image: "osig/prometheus-cloudflare-exporter"
+          before_build:
+            - attach_workspace:
+                at: ./
+          tag: "$CIRCLE_TAG"
+          dockerfile: "Dockerfile"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 .idea
 *.pyc
+
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
-FROM 234348545939.dkr.ecr.eu-west-1.amazonaws.com/wehkamp/alpine:3.5
+FROM python:3-slim AS build-env
 
-ENTRYPOINT ["python", "-m", "exporter"]
-EXPOSE 9199
-ENV FLASK_APP=/exporter/exporter/app.py \
-    SERVICE_PORT=9199
+WORKDIR /exporter
 
-RUN LAYER=build \
-  && apk add -U python py-pip \
-  && pip install prometheus_client delorean requests apscheduler Flask \
-  && rm -rf /var/cache/apk/* \
-  && rm -rf ~/.cache/pip
+ADD requirements.txt /exporter
+
+RUN pip install --target="/exporter/pip" --requirement="/exporter/requirements.txt" \
+      && rm -rf ~/.cache/pip
 
 ADD ./exporter /exporter
 
-LABEL container.name=wehkamp/prometheus-cloudflare-exporter:1.1.1
+FROM gcr.io/distroless/python3
+ENTRYPOINT ["python", "-m", "exporter"]
+EXPOSE 9199
+ENV FLASK_APP=/app/exporter/app.py \
+    SERVICE_PORT=9199 \
+    PYTHONPATH=$PYTHONPATH:/app/exporter/pip
+
+WORKDIR /app
+
+COPY --from=build-env /exporter /app/exporter

--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ Overview of requests served per Cloudflare network point-of-presence:
 Overview of actual countries that cause threats:
 ![Attacking Countries](./docs/assets/threats.png)
 
+### Deploy a new image
+
+To publish a new version you need to create a new git tag to mark a new release. Tagging the commit triggers a CircleCI
+pipeline to build and publish a new Docker image.
+
+```
+git tag 1.2.0
+git push --tags
+```
+
+The Docker images are hosted at [Docker Hub](https://hub.docker.com/repository/docker/osig/prometheus-cloudflare-exporter)
+
 ### Todo
 
 - [ ] Implement a way to store datapoints in Prometheus using timestamps received from Cloudflare. This should remove the delay as we currently have it.

--- a/exporter/coloexporter.py
+++ b/exporter/coloexporter.py
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     path = os.path.join(source_dir, "sample")
 
     with open(path) as f:
-        print process(json.load(f)['result'])
+        print(process(json.load(f)['result']))

--- a/exporter/dnsexporter.py
+++ b/exporter/dnsexporter.py
@@ -50,4 +50,4 @@ if __name__ == "__main__":
     path = os.path.join(source_dir, "sample-dns")
 
     with open(path) as f:
-        print process(json.load(f)['result'])
+        print(process(json.load(f)['result']))

--- a/exporter/wafexporter.py
+++ b/exporter/wafexporter.py
@@ -121,4 +121,4 @@ if __name__ == "__main__":
     path = os.path.join(source_dir, "sample-waf")
 
     with open(path) as f:
-        print process(json.load(f)['result'])
+        print(process(json.load(f)['result']))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+prometheus_client==0.8.0
+Delorean==1.0.0
+requests==2.24.0
+APScheduler==3.6.3
+Flask==1.1.2


### PR DESCRIPTION
In https://github.com/wehkamp/docker-prometheus-cloudflare-exporter/pull/17 Wehkamp changes their docker image to use a private AWS ECR registry and removed their public image. With this PR we will replace the public image with one of our own.

We also versioned the python dependencies in the requirements.txt file.